### PR TITLE
Patch #6

### DIFF
--- a/protoAge4StatlessOverrides.xml
+++ b/protoAge4StatlessOverrides.xml
@@ -291,6 +291,10 @@
 			<ImpactEffect>effects\impacts\meleelite</ImpactEffect>
 		</ProtoAction>
 		<Tactics>pvp_spearman.tactics</Tactics>
+		<ProtoAction> <!-- EDIT ADD-->
+			<Name>Build</Name>
+			<Rate type ='Building'>0.750000</Rate>
+		</ProtoAction>
 	</ProtoUnitOverride>
 	<ProtoUnitOverride name="Gr_Bldg_LookoutTower">
 		<BuildPoints>20.0000</BuildPoints>
@@ -324,6 +328,7 @@
 	</ProtoUnitOverride>
 	<ProtoUnitOverride name="No_Bldg_Fortress">
 		<MaxHitpoints>6750.0000</MaxHitpoints>
+		<BuilderLimit>40</BuilderLimit> <!--edit add-->
 	</ProtoUnitOverride>
 	<ProtoUnitOverride name="Gr_Bldg_GuardTower">
 		<BuildPoints>60.0000</BuildPoints> <!--edit add-->
@@ -606,6 +611,10 @@
 	<ProtoUnitOverride name="No_Inf_Chief">
 		<Cost resourcetype="Food">300.0000</Cost>
 		<Cost resourcetype="Gold">300.0000</Cost>
+		<ProtoAction> <!-- EDIT ADD-->
+			<Name>Build</Name>
+			<Rate type ='Building'>1.200000</Rate>
+		</ProtoAction>
 	</ProtoUnitOverride>	
 	<ProtoUnitOverride name="Gr_Bldg_Temple">
 		<Cost resourcetype="Wood">250.0000</Cost>
@@ -660,6 +669,30 @@
 		<ProtoAction>
 			<Name>RangedAttack</Name>
 			<MaxRange>18.000000</MaxRange>
+		</ProtoAction>
+	</ProtoUnitOverride>
+	<ProtoUnitOverride name="No_Inf_Axeman">
+		<ProtoAction> <!-- EDIT ADD-->
+			<Name>Build</Name>
+			<Rate type ='Building'>0.750000</Rate>
+		</ProtoAction>
+	</ProtoUnitOverride>
+	<ProtoUnitOverride name="No_Inf_Berserker">
+		<ProtoAction> <!-- EDIT ADD-->
+			<Name>Build</Name>
+			<Rate type ='Building'>0.750000</Rate>
+		</ProtoAction>
+	</ProtoUnitOverride>
+	<ProtoUnitOverride name="No_Inf_Ulfhednar">
+		<ProtoAction> <!-- EDIT ADD-->
+			<Name>Build</Name>
+			<Rate type ='Building'>0.750000</Rate>
+		</ProtoAction>
+	</ProtoUnitOverride>
+	<ProtoUnitOverride name="No_Inf_ThrowingAxeman">
+		<ProtoAction> <!-- EDIT ADD-->
+			<Name>Build</Name>
+			<Rate type ='Building'>0.750000</Rate>
 		</ProtoAction>
 	</ProtoUnitOverride>
 			

--- a/techtreex.xml
+++ b/techtreex.xml
@@ -31392,4 +31392,48 @@
 		</Effects>
 	</Tech>
 	
+	<Tech name="PVP_CeltTechGoldmine_Upgrade1" type="Normal">
+		<DBID>5739</DBID>
+		<DisplayNameID>66332</DisplayNameID>
+		<Cost resourcetype="Wood">150.0000</Cost>
+		<ResearchPoints>30.0000</ResearchPoints>
+		<Status>UNOBTAINABLE</Status>
+		<Icon>\UserInterface\Icons\Techs\C03TechCargoExpansion_ua</Icon>
+		<RolloverTextID>66331</RolloverTextID>
+		<ContentPack>22</ContentPack>
+		<Flag>IsAward</Flag>
+		<Prereqs>
+			<SpecificAge>Age2</SpecificAge>
+			<TechStatus status="Active">PVP_CeltCapAge3</TechStatus>
+		</Prereqs>
+		<Effects>
+			<Effect type="Data" amount="5.0000" scaling="0.0000" subtype="MaximumContained" relativity="Absolute">
+				<Target type="ProtoUnit">Ce_Bldg_GoldMine</Target>
+			</Effect>
+		</Effects>
+	</Tech>
+	
+	<Tech name="PVP_NorseTechRaider_Upgrade1" type="Normal">
+		<DBID>5740</DBID>
+		<DisplayNameID>67587</DisplayNameID>
+		<Cost resourcetype="Gold">300.0000</Cost>
+		<ResearchPoints>40.0000</ResearchPoints>
+		<Status>UNOBTAINABLE</Status>
+		<Icon>\UserInterface\Icons\Techs\C07TechRaiderChampion_ua</Icon>
+		<RolloverTextID>110041</RolloverTextID>
+		<ContentPack>24</ContentPack>
+		<Flag>IsAward</Flag>
+		<Prereqs>
+			<SpecificAge>Age2</SpecificAge>
+		</Prereqs>
+		<Effects>
+			<Effect type="SetName" proto="No_Cav_Raider" culture="none" newName="67589"/>
+			<Effect type="Data" amount="1.5000" scaling="0.0000" subtype="DamageBonus" unittype="UnitTypeVillager1" allactions="1" relativity="Percent">
+				<Target type="ProtoUnit">No_Cav_Raider</Target>
+			</Effect>
+			<Effect type="Data" amount="1.7500" scaling="0.0000" subtype="TargetSpeedBoostResist" relativity="Percent">
+				<Target type="ProtoUnit">No_Cav_Raider</Target>
+			</Effect>
+		</Effects>
+	</Tech>
 </TechTree>

--- a/techtreexStatlessOverrides.xml
+++ b/techtreexStatlessOverrides.xml
@@ -81,5 +81,6 @@
 	<!-- UNIT - NO -->
 	
 	<Tech name="NorseTechBurningPitch1">PVP_NorseTechBurningPitch1</Tech>
+	<Tech name="NorseTechRaider_Upgrade1">PVP_NorseTechRaider_Upgrade1</Tech>
 	
 </TechTreeOverrides>


### PR DESCRIPTION
Norse Infantry: Build Speed decreased to 75% (100% being as fast as villagers)

Norse Chief: Build Speed increased to 120%, from 100%

Norse Raider: Champion upgrade changed to +50% bonus vs vills and 75% snare resistance, from +100% bonus vs vills and snare Immunity

Global | Caravans: Pierce armor increased to 0.30 to match villagers, from 0.00