### PR TITLE
Balance Patch #6.2

### DIFF
--- a/protoAge4StatlessOverrides.xml
+++ b/protoAge4StatlessOverrides.xml
@@ -703,6 +703,15 @@
 			<Name>Build</Name>
 			<Rate type ='Building'>0.750000</Rate>
 		</ProtoAction>
+		<ProtoAction>
+			<Name>MeleeAttack</Name>
+			<Damage>30.000000</Damage>
+			<ROF>0.000000</ROF>
+			<DamageFlags>Gaia Enemy</DamageFlags>
+			<DamageType>Hand</DamageType>
+			<ImpactEffect>effects\impacts\sword</ImpactEffect>
+		</ProtoAction>	
+		<Tactics>pvp_berserker.tactics</Tactics>		
 	</ProtoUnitOverride>
 	<ProtoUnitOverride name="No_Inf_Ulfhednar">
 		<ProtoAction> <!-- EDIT ADD-->
@@ -723,5 +732,5 @@
 	<ProtoUnitOverride name="Eg_Arc_ElephantArcher">
 		<MaxHitpoints>770.0000</MaxHitpoints>
 	</ProtoUnitOverride>	
-			
+						
 </ProtoUnitOverrides>

--- a/pvp_berserker.tactics
+++ b/pvp_berserker.tactics
@@ -1,0 +1,93 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+
+<tactics>
+	<action>
+		<name stringid="58251">MeleeAttack</name>
+		<type>Attack</type>
+		<maxrange>1.75</maxrange>
+		<rate type="All">1.0 </rate>
+		<attackaction>1</attackaction>
+		<handlogic>1</handlogic>
+		<anim>MeleeAttack</anim>
+		<hitpercentanim hitpercenttype="CriticalAttack">CriticalHit</hitpercentanim>
+		<hitpercentanim hitpercenttype="KillingBlow">Finisher</hitpercentanim>
+		<impacteffect>effects\impacts\melee</impacteffect>
+		<basedamagecap>1</basedamagecap>
+		<targetspeedboost>1.0</targetspeedboost>
+		<hitpercentdamagemultiplier>2.0</hitpercentdamagemultiplier>
+		<hitpercent>1.0</hitpercent>
+		<hitpercenttype>CriticalAttack</hitpercenttype>
+	</action>
+	<action>
+		<name stringid="58252">BuildingAttack</name>
+		<type>Attack</type>
+		<attackaction>1</attackaction>
+		<handlogic>1</handlogic>
+		<anim>BuildingAttack</anim>
+		<maxrange>2</maxrange>
+		<rate type="Building">1.0</rate>
+		<impacteffect>effects\impacts\melee</impacteffect>
+		<active>0</active>
+	</action>
+	<action>
+		<name>Charge</name>
+		<type>Charge</type>
+		<maxrange>20.0</maxrange>
+		<rate type="All">1.0</rate>
+		<timer>8.0</timer>
+		<damagebonus type="All">1.0</damagebonus>
+		<targetspeedboost>1.50</targetspeedboost>
+		<active>0</active>
+	</action>
+	<action>
+		<name>Build</name>
+		<type>Build</type>
+		<anim>Build</anim>
+		<maxrange>0.2</maxrange>
+		<rate type="Building">1.0</rate>
+	</action>
+	<action>
+		<name>Heal</name>
+		<type>Heal</type>
+		<active>0</active>
+		<maxrange>12</maxrange>
+		<rate type="LogicalTypeHealed">50.0 </rate>
+		<anim>Heal</anim>
+	</action>
+	<action>
+		<name stringid="57824">SelfHeal</name>
+		<type>Heal</type>
+		<active>0</active>
+		<maxrange>12</maxrange>
+		<rate type="LogicalTypeHealed">2.0 </rate>
+		<persistent>1</persistent>
+	</action>
+	<action>
+		<name>Discover</name>
+		<type>Discover</type>
+		<anim>Idle</anim>
+		<maxrange>5.0</maxrange>
+		<rate type="AbstractNugget">0.1</rate>
+	</action>
+	<tactic>
+		Melee
+		<action priority="100">BuildingAttack</action>
+		<action priority="90">MeleeAttack</action>
+		<action>Charge</action>
+		<action>Build</action>
+		<action>Heal</action>
+		<action>Discover</action>
+		<action>SelfHeal</action>
+		<speedmodifier>1.0</speedmodifier>
+		<attacktype>LogicalTypeHandUnitsAttack</attacktype>
+		<autoattacktype>LogicalTypeHandUnitsAutoAttack</autoattacktype>
+		<attackresponsetype>LogicalTypeHandUnitsAttack</attackresponsetype>
+		<runaway>1</runaway>
+		<autoretarget>1</autoretarget>
+		<idleanim>Idle</idleanim>
+		<boredanim>Bored</boredanim>
+		<deathanim>Death</deathanim>
+		<walkanim>Walk</walkanim>
+		<joganim>Jog</joganim>
+	</tactic>
+</tactics>

--- a/techtreex.xml
+++ b/techtreex.xml
@@ -31527,7 +31527,7 @@
 			<Effect type="Data" amount="-1.0000" scaling="0.0000" subtype="PopulationCount" relativity="Absolute">
 				<Target type="ProtoUnit">Eg_Arc_ElephantArcher</Target>
 			</Effect>
-			<Effect type="Data" amount="1.5000" scaling="0.0000" subtype="Armor" damagetype="Cavalry" relativity="Percent">
+			<Effect type="Data" amount="1.3000" scaling="0.0000" subtype="Armor" damagetype="Cavalry" relativity="Percent">
 				<Target type="ProtoUnit">Eg_Arc_ElephantArcher</Target>
 			</Effect>				
 			<Effect type="SetName" proto="Eg_Arc_ElephantArcher" culture="none" newName="64561"/>

--- a/techtreex.xml
+++ b/techtreex.xml
@@ -31565,4 +31565,31 @@
 			</Effect>			
 		</Effects>
 	</Tech>	
+	
+	<Tech name="PVP_NorseTechBerserker_Upgrade1" type="Normal">
+		<DBID>5746</DBID>
+		<DisplayNameID>67580</DisplayNameID>
+		<Cost resourcetype="Gold">1200.0000</Cost>
+		<ResearchPoints>60.0000</ResearchPoints>
+		<Status>UNOBTAINABLE</Status>
+		<Icon>\UserInterface\Icons\Techs\C07TechBerserkerChampion_ua</Icon>
+		<RolloverTextID>110047</RolloverTextID>
+		<ContentPack>24</ContentPack>
+		<Flag>IsAward</Flag>
+		<Prereqs>
+			<SpecificAge>Age3</SpecificAge>
+		</Prereqs>
+		<Effects>
+			<Effect type="SetName" proto="No_Inf_Berserker" culture="none" newName="67583"/>
+			<Effect type="Data" action="SelfHeal" amount="1.0000" scaling="0.0000" subtype="ActionEnable" relativity="Assign">
+				<Target type="ProtoUnit">No_Inf_Berserker</Target>
+			</Effect>
+			<Effect type="Data" action="Charge" amount="1.0000" scaling="0.0000" subtype="ActionEnable" relativity="Absolute">
+				<Target type="ProtoUnit">No_Inf_Berserker</Target>
+			</Effect>
+			<Effect type="Data" amount="1000.0000" scaling="0.0000" subtype="TargetSpeedBoostResist" relativity="Percent">
+				<Target type="ProtoUnit">No_Inf_Berserker</Target>
+			</Effect>
+		</Effects>
+	</Tech>		
 </TechTree>

--- a/techtreex.xml
+++ b/techtreex.xml
@@ -31452,7 +31452,7 @@
         <ResearchPoints>1.0000</ResearchPoints>
         <Status>UNOBTAINABLE</Status>
         <Icon>\UserInterface\Icons\Techs\C04TechPaidLabor_ua</Icon>
-        <RolloverTextID>62116</RolloverTextID>
+        <RolloverTextID>110045</RolloverTextID>
         <ContentPack>6</ContentPack>
         <Flag>IsAward</Flag>
         <Prereqs>

--- a/techtreex.xml
+++ b/techtreex.xml
@@ -19912,12 +19912,12 @@
 	</Tech>
 	<Tech name="PVP_CeltTechVillager1" type="Normal"> <!--EDIT org is the same as CeltTechVillager1 but the cost is 150f/150g and the research time is 40s instead of 20s-->
 		<DBID>5178</DBID>
-		<DisplayNameID>110042</DisplayNameID> <!--EDIT ORG 64183-->
+		<DisplayNameID>110043</DisplayNameID> <!--EDIT ORG 64183-->
 		<Cost resourcetype="Wood">150.0000</Cost>
 		<ResearchPoints>30.0000</ResearchPoints>
 		<Status>UNOBTAINABLE</Status>
 		<Icon>\UserInterface\Icons\Techs\C03TechCargoExpansion_ua</Icon> <!--edit org C03TechCalltoArms_ua-->
-		<RolloverTextID>110043</RolloverTextID> <!--EDIT ORG 64182-->
+		<RolloverTextID>110042</RolloverTextID> <!--EDIT ORG 64182-->
 		<ContentPack>5</ContentPack>
 		<Flag>IsAward</Flag>
 		<Prereqs>
@@ -29529,7 +29529,7 @@
 		<Flag>AgeUpgrade</Flag>
 		<Flag>IsAward</Flag>
 		<Prereqs>
-			<TechStatus status="Active">NorseCapAge2</TechStatus>
+			<TechStatus status="Active">PVP_NorseCapAge2</TechStatus>
 		</Prereqs>
 		<Effects>
 			<Effect type="SetAge">Age2</Effect>
@@ -29547,7 +29547,10 @@
 			</Effect>
 			<Effect type="Data" amount="1.2500" scaling="0.0000" subtype="DamageBonus" unittype="AbstractArcher" allactions="1" relativity="Percent"> <!--EDIT ADDED-->
 				<Target type="ProtoUnit">AbstractGuardTower</Target>
-			</Effect>				
+			</Effect>	
+			<Effect type="Data" action="MeleeAttack" amount="1.0000" scaling="0.0000" subtype="DamageArea" relativity="Absolute">
+				<Target type="ProtoUnit">No_Inf_Berserker</Target>
+			</Effect>
 		</Effects>
 	</Tech>
 	<Tech name="NorthernHero01_Action02" type="Normal">
@@ -31511,7 +31514,7 @@
 	</Tech>
 	
 	<Tech name="PVP_EgyptTechElephantArcher_Upgrade1" type="Normal">
-		<DBID>5229</DBID>
+		<DBID>5744</DBID>
 		<DisplayNameID>64560</DisplayNameID>
 		<Cost resourcetype="Gold">1200.0000</Cost>
 		<ResearchPoints>60.0000</ResearchPoints>
@@ -31527,10 +31530,39 @@
 			<Effect type="Data" amount="-1.0000" scaling="0.0000" subtype="PopulationCount" relativity="Absolute">
 				<Target type="ProtoUnit">Eg_Arc_ElephantArcher</Target>
 			</Effect>
-			<Effect type="Data" amount="1.3000" scaling="0.0000" subtype="Armor" damagetype="Cavalry" relativity="Percent">
+			<Effect type="Data" amount="1.5000" scaling="0.0000" subtype="Armor" damagetype="Cavalry" relativity="Percent">
 				<Target type="ProtoUnit">Eg_Arc_ElephantArcher</Target>
 			</Effect>				
 			<Effect type="SetName" proto="Eg_Arc_ElephantArcher" culture="none" newName="64561"/>
+		</Effects>
+	</Tech>	
+
+	<Tech name="PVP_NorseCapAge2" type="Normal">
+		<DBID>5745</DBID>
+		<DisplayNameID>67453</DisplayNameID>
+		<Cost resourcetype="Food">200.0000</Cost>
+		<Cost resourcetype="Wood">200.0000</Cost>
+		<ResearchPoints>45.0000</ResearchPoints>
+		<Status>UNOBTAINABLE</Status>
+		<Icon>UserInterface\Icons\Techs\AgeUpL2_ua</Icon>
+		<RolloverTextID>67452</RolloverTextID>
+		<ContentPack>24</ContentPack>
+		<Flag>AgeUpgrade</Flag>
+		<Flag>IsAward</Flag>
+		<Effects>
+			<Effect type="SetAge">Age1</Effect>
+			<Effect type="Data" amount="1.3330" scaling="0.0000" subtype="Damage" allactions="1" relativity="Percent">
+				<Target type="ProtoUnit">AbstractTownCenter</Target>
+			</Effect>
+			<Effect type="Data" amount="1.3330" scaling="0.0000" subtype="Hitpoints" relativity="Percent">
+				<Target type="ProtoUnit">AbstractTownCenter</Target>
+			</Effect>
+			<Effect type="Data" amount="1.0000" scaling="0.0000" subtype="BuildLimit" relativity="Absolute">
+				<Target type="ProtoUnit">No_Bldg_TownCenter</Target>
+			</Effect>
+			<Effect type="Data" action="MeleeAttack" amount="1.0000" scaling="0.0000" subtype="DamageArea" relativity="Absolute">
+				<Target type="ProtoUnit">No_Inf_Berserker</Target>
+			</Effect>			
 		</Effects>
 	</Tech>	
 </TechTree>

--- a/techtreexStatlessOverrides.xml
+++ b/techtreexStatlessOverrides.xml
@@ -85,5 +85,7 @@
 	
 	<Tech name="NorseTechBurningPitch1">PVP_NorseTechBurningPitch1</Tech>
 	<Tech name="NorseTechRaider_Upgrade1">PVP_NorseTechRaider_Upgrade1</Tech>
-	<Tech name="NorseCapAge2">PVP_NorseCapAge2</Tech>	
+	<Tech name="NorseCapAge2">PVP_NorseCapAge2</Tech>
+	<Tech name="NorseTechBerserker_Upgrade1">PVP_NorseTechBerserker_Upgrade1</Tech>	
+	
 </TechTreeOverrides>

--- a/techtreexStatlessOverrides.xml
+++ b/techtreexStatlessOverrides.xml
@@ -85,5 +85,5 @@
 	
 	<Tech name="NorseTechBurningPitch1">PVP_NorseTechBurningPitch1</Tech>
 	<Tech name="NorseTechRaider_Upgrade1">PVP_NorseTechRaider_Upgrade1</Tech>
-	
+	<Tech name="NorseCapAge2">PVP_NorseCapAge2</Tech>	
 </TechTreeOverrides>


### PR DESCRIPTION
**Norse | Berserkers**: Charge behavior changed: 50% Speedboost while charging, from 75%. 8 second charge with 4 second cooldown, from infinite charge. Charge range increased to 20, from 18. Berserker Champion health regeneration decreased to 2, from 4.

 ------
**Global | Caravans and Merchant Transports**: Minor tweaks implemented to improve these units' pathing so that they get stuck less often.

> https://www.dropbox.com/s/czbrwygtazdwdea/New%20Caravan%20Pathing.mp4?dl=0
> 
> https://www.dropbox.com/s/mavh5lxdkxqtz2h/New%20Caravan%20Pathing%202.mp4?dl=0
