### PR TITLE
PvP Patches #7 and #7.1

### DIFF
--- a/protoAge4StatlessOverrides.xml
+++ b/protoAge4StatlessOverrides.xml
@@ -50,10 +50,10 @@
 		<ProtoAction>
 			<Name>Convert</Name>
 			<MaxRange>22.000000</MaxRange>
-			<Rate type="StandardConvertable">16.000000</Rate>
-			<Rate type="ConvertableCavalry">16.000000</Rate>
-			<Rate type="ConvertableInfantry">16.000000</Rate>
-			<Rate type="ConvertableSiege">16.000000</Rate>
+			<Rate type="StandardConvertable">15.000000</Rate> <!--edit org 16-->
+			<Rate type="ConvertableCavalry">15.000000</Rate> <!--edit org 16-->
+			<Rate type="ConvertableInfantry">15.000000</Rate> <!--edit org 16-->
+			<Rate type="ConvertableSiege">15.000000</Rate> <!--edit org 16-->
 		</ProtoAction>
 		<ProtoAction> <!--edit add-->
 			<Name>Heal</Name>
@@ -71,13 +71,14 @@
 		</ProtoAction>
 	</ProtoUnitOverride>
 	<ProtoUnitOverride name="Pe_Spc_Magus">
+		<MaxHitpoints>140.0000</MaxHitpoints> <!-- edit add-->
 		<ProtoAction>
 			<Name>Convert</Name>
 			<MaxRange>22.000000</MaxRange>&gt;
-			<Rate type="StandardConvertable">16.000000</Rate>
-			<Rate type="ConvertableCavalry">16.000000</Rate>
-			<Rate type="ConvertableInfantry">16.000000</Rate>
-			<Rate type="ConvertableSiege">16.000000</Rate>
+			<Rate type="StandardConvertable">15.000000</Rate> <!--edit org 16-->
+			<Rate type="ConvertableCavalry">15.000000</Rate> <!--edit org 16-->
+			<Rate type="ConvertableInfantry">15.000000</Rate> <!--edit org 16-->
+			<Rate type="ConvertableSiege">15.000000</Rate> <!--edit org 16-->
 		</ProtoAction>
 		<ProtoAction> <!--edit add-->
 			<Name>Heal</Name>
@@ -89,10 +90,10 @@
 		<ProtoAction>
 			<Name>Convert</Name>
 			<MaxRange>22.000000</MaxRange>&gt;
-			<Rate type="StandardConvertable">16.000000</Rate>
-			<Rate type="ConvertableCavalry">16.000000</Rate>
-			<Rate type="ConvertableInfantry">16.000000</Rate>
-			<Rate type="ConvertableSiege">16.000000</Rate>
+			<Rate type="StandardConvertable">15.000000</Rate> <!--edit org 16-->
+			<Rate type="ConvertableCavalry">15.000000</Rate> <!--edit org 16-->
+			<Rate type="ConvertableInfantry">15.000000</Rate> <!--edit org 16-->
+			<Rate type="ConvertableSiege">15.000000</Rate> <!--edit org 16-->
 		</ProtoAction>
 		<ProtoAction> <!--edit add-->
 			<Name>Heal</Name>
@@ -104,10 +105,10 @@
 		<ProtoAction>
 			<Name>Convert</Name>
 			<MaxRange>22.000000</MaxRange>&gt;
-			<Rate type="StandardConvertable">16.000000</Rate>
-			<Rate type="ConvertableCavalry">16.000000</Rate>
-			<Rate type="ConvertableInfantry">16.000000</Rate>
-			<Rate type="ConvertableSiege">16.000000</Rate>
+			<Rate type="StandardConvertable">15.000000</Rate> <!--edit org 16-->
+			<Rate type="ConvertableCavalry">15.000000</Rate> <!--edit org 16-->
+			<Rate type="ConvertableInfantry">15.000000</Rate> <!--edit org 16-->
+			<Rate type="ConvertableSiege">15.000000</Rate> <!--edit org 16-->
 		</ProtoAction>
 		<ProtoAction> <!--edit add-->
 			<Name>Heal</Name>
@@ -119,20 +120,20 @@
 		<ProtoAction>
 			<Name>Convert</Name>
 			<MaxRange>22.000000</MaxRange>&gt;
-			<Rate type="StandardConvertable">16.000000</Rate>
-			<Rate type="ConvertableCavalry">16.000000</Rate>
-			<Rate type="ConvertableInfantry">16.000000</Rate>
-			<Rate type="ConvertableSiege">16.000000</Rate>
+			<Rate type="StandardConvertable">15.000000</Rate> <!--edit org 16-->
+			<Rate type="ConvertableCavalry">15.000000</Rate> <!--edit org 16-->
+			<Rate type="ConvertableInfantry">15.000000</Rate> <!--edit org 16-->
+			<Rate type="ConvertableSiege">15.000000</Rate> <!--edit org 16-->
 		</ProtoAction>
 	</ProtoUnitOverride>
 	<ProtoUnitOverride name="No_Spc_Bard">
 		<ProtoAction>
 			<Name>Convert</Name>
 			<MaxRange>22.000000</MaxRange>&gt;
-			<Rate type="StandardConvertable">16.000000</Rate>
-			<Rate type="ConvertableCavalry">16.000000</Rate>
-			<Rate type="ConvertableInfantry">16.000000</Rate>
-			<Rate type="ConvertableSiege">16.000000</Rate>
+			<Rate type="StandardConvertable">15.000000</Rate> <!--edit org 16-->
+			<Rate type="ConvertableCavalry">15.000000</Rate> <!--edit org 16-->
+			<Rate type="ConvertableInfantry">15.000000</Rate> <!--edit org 16-->
+			<Rate type="ConvertableSiege">15.000000</Rate> <!--edit org 16-->
 		</ProtoAction>
 	</ProtoUnitOverride>
 	<ProtoUnitOverride name="Gr_Bldg_SiegeWorkshop">
@@ -444,6 +445,11 @@
 			<Rate type="ConvertableInfantry">13.000000</Rate>
 			<Rate type="ConvertableSiege">13.000000</Rate>
 		</ProtoAction>
+		<ProtoAction> <!--edit add-->
+			<Name>Heal</Name>
+			<Rate type ='LogicalTypeHealed'>40.000000</Rate>
+			<MaxRange>16.000000</MaxRange>
+		</ProtoAction>			
 	</ProtoUnitOverride>
 	<ProtoUnitOverride name="Eg_Spc_PriestPtah">
 		<TrainPoints>30.0000</TrainPoints>
@@ -466,6 +472,15 @@
 		<Cost resourcetype="Gold">60.0000</Cost>
 		<MaxVelocity>10.0000</MaxVelocity>
 		<MaxRunVelocity>15.00000</MaxRunVelocity>
+		<ProtoAction> <!--EDIT ADD-->
+			<Name>RangedAttack</Name>
+			<Damage>14.000000</Damage>
+			<ROF>0.000000</ROF>
+			<MaxRange>15.000000</MaxRange>
+			<DamageType>Ranged</DamageType>
+			<MaxHeight>0.200000</MaxHeight>
+			<DamageBonus type ='AbstractCavalry'>2.300000</DamageBonus>
+		</ProtoAction>		
 	</ProtoUnitOverride>
 	<ProtoUnitOverride name="Pe_Cav_Cataphract">
 		<MaxVelocity>9.0000</MaxVelocity> <!--EDIT +1-->
@@ -648,7 +663,7 @@
 		</ProtoAction>
 	</ProtoUnitOverride>
 	<ProtoUnitOverride name="Ce_Inf_Champion">
-		<MaxHitpoints>420.0000</MaxHitpoints>
+		<MaxHitpoints>450.0000</MaxHitpoints>
 		<MaxVelocity>5.5000</MaxVelocity>
 		<MaxRunVelocity>8.2500</MaxRunVelocity>
 	</ProtoUnitOverride>
@@ -710,8 +725,8 @@
 			<DamageFlags>Gaia Enemy</DamageFlags>
 			<DamageType>Hand</DamageType>
 			<ImpactEffect>effects\impacts\sword</ImpactEffect>
-		</ProtoAction>	
-		<Tactics>pvp_berserker.tactics</Tactics>		
+		</ProtoAction>
+		<Tactics>pvp_berserker.tactics</Tactics>			
 	</ProtoUnitOverride>
 	<ProtoUnitOverride name="No_Inf_Ulfhednar">
 		<ProtoAction> <!-- EDIT ADD-->

--- a/techtreex.xml
+++ b/techtreex.xml
@@ -15734,7 +15734,7 @@
 			<Effect type="Data" amount="40.0000" scaling="0.0000" subtype="Cost" resource="Gold" relativity="Absolute">
 				<Target type="ProtoUnit">Pe_Civ_Villager</Target>
 			</Effect>
-			<Effect type="Data" amount="0.5500" scaling="0.0000" subtype="TrainPoints" relativity="Percent">
+			<Effect type="Data" amount="0.6667" scaling="0.0000" subtype="TrainPoints" relativity="Percent"> <!-- edit org 0.5500-->
 				<Target type="ProtoUnit">Pe_Civ_Villager</Target>
 			</Effect>
 		</Effects>
@@ -18155,7 +18155,7 @@
 		<ResearchPoints>1.0000</ResearchPoints>
 		<Status>UNOBTAINABLE</Status>
 		<Icon>\UserInterface\Icons\Techs\C04TechPaidLabor_ua</Icon>
-		<RolloverTextID>62116</RolloverTextID>
+		<RolloverTextID>110045</RolloverTextID> <!--edit org 62116-->
 		<ContentPack>6</ContentPack>
 		<Flag>IsAward</Flag>
 		<Prereqs>
@@ -29408,6 +29408,7 @@
 			<SpecificAge>Age3</SpecificAge>
 		</Prereqs>
 		<Effects>
+			<Effect type="SetName" proto="No_Inf_Chief" culture="none" newName="67598"/>		
 			<Effect type="Data" amount="1.5000" scaling="0.0000" subtype="Damage" allactions="1" relativity="Percent">
 				<Target type="ProtoUnit">No_Inf_Chief</Target>
 			</Effect>
@@ -31489,8 +31490,8 @@
 	<Tech name="PVP_PersiaTechBatteringRam_Upgrade1" type="Normal">
 		<DBID>5743</DBID>
 		<DisplayNameID>64601</DisplayNameID>
-		<Cost resourcetype="Gold">400.0000</Cost>
-		<ResearchPoints>60.0000</ResearchPoints>
+		<Cost resourcetype="Gold">300.0000</Cost>
+		<ResearchPoints>30.0000</ResearchPoints>
 		<Status>UNOBTAINABLE</Status>
 		<Icon>UserInterface\Icons\Techs\GreekTechRamS_ua</Icon>
 		<RolloverTextID>64600</RolloverTextID>
@@ -31592,4 +31593,194 @@
 			</Effect>
 		</Effects>
 	</Tech>		
+
+	<Tech name="PVP_GreekTechRam_Upgrade1" type="Normal">
+		<DBID>5747</DBID>
+		<DisplayNameID>64470</DisplayNameID>
+		<Cost resourcetype="Gold">300.0000</Cost>
+		<ResearchPoints>30.0000</ResearchPoints>
+		<Status>UNOBTAINABLE</Status>
+		<Icon>UserInterface\Icons\Techs\GreekTechRamS_ua</Icon>
+		<RolloverTextID>64469</RolloverTextID>
+		<ContentPack>1</ContentPack>
+		<Flag>IsAward</Flag>
+		<Prereqs>
+			<SpecificAge>Age3</SpecificAge>
+		</Prereqs>
+		<Effects>
+			<Effect type="Data" amount="1.5000" scaling="0.0000" subtype="Damage" allactions="1" relativity="Percent">
+				<Target type="ProtoUnit">Gr_Sie_BatteringRam</Target>
+			</Effect>
+			<Effect type="Data" amount="1000.0000" scaling="0.0000" subtype="TargetSpeedBoostResist" relativity="Percent">
+				<Target type="ProtoUnit">Gr_Sie_BatteringRam</Target>
+			</Effect>
+			<Effect type="SetName" proto="Gr_Sie_BatteringRam" culture="none" newName="64471"/>
+		</Effects>
+	</Tech>
+
+	<Tech name="PVP_EgyptTechSiegeTower_Upgrade1" type="Normal">
+		<DBID>5748</DBID>
+		<DisplayNameID>64566</DisplayNameID>
+		<Cost resourcetype="Gold">300.0000</Cost>
+		<ResearchPoints>30.0000</ResearchPoints>
+		<Status>UNOBTAINABLE</Status>
+		<Icon>UserInterface\Icons\Techs\EgyptTechSiegeTowerS_ua</Icon>
+		<RolloverTextID>64565</RolloverTextID>
+		<ContentPack>2</ContentPack>
+		<Flag>IsAward</Flag>
+		<Prereqs>
+			<SpecificAge>Age3</SpecificAge>
+		</Prereqs>
+		<Effects>
+			<Effect type="Data" amount="1000.0000" scaling="0.0000" subtype="TargetSpeedBoostResist" relativity="Percent">
+				<Target type="ProtoUnit">Eg_Sie_SiegeTower</Target>
+			</Effect>
+			<Effect type="Data" amount="1.5000" scaling="0.0000" subtype="Hitpoints" relativity="Percent">
+				<Target type="ProtoUnit">Eg_Sie_SiegeTower</Target>
+			</Effect>
+			<Effect type="SetName" proto="Eg_Sie_SiegeTower" culture="none" newName="64567"/>
+		</Effects>
+	</Tech>	
+	
+	<Tech name="PVP_PersiaTechZorostrianConvert1" type="Normal">
+		<DBID>5749</DBID>
+		<DisplayNameID>61348</DisplayNameID>
+		<Cost resourcetype="Gold">800.0000</Cost>
+		<ResearchPoints>60.0000</ResearchPoints>
+		<Status>UNOBTAINABLE</Status>
+		<Icon>\UserInterface\Icons\Techs\C04WithoutNumber_ua</Icon>
+		<RolloverTextID>110048</RolloverTextID>
+		<ContentPack>6</ContentPack>
+		<Flag>IsAward</Flag>
+		<Prereqs>
+			<SpecificAge>Age3</SpecificAge>
+		</Prereqs>
+		<Effects>
+			<Effect type="Data" action="Convert" amount="0.6668" scaling="0.0000" subtype="WorkRate" unittype="StandardConvertable" relativity="Percent">
+				<Target type="ProtoUnit">Pe_Spc_Magus</Target>
+			</Effect>
+			<Effect type="Data" action="Convert" amount="0.6668" scaling="0.0000" subtype="WorkRate" unittype="ConvertableInfantry" relativity="Percent">
+				<Target type="ProtoUnit">Pe_Spc_Magus</Target>
+			</Effect>
+			<Effect type="Data" action="Convert" amount="0.6668" scaling="0.0000" subtype="WorkRate" unittype="ConvertableCavalry" relativity="Percent">
+				<Target type="ProtoUnit">Pe_Spc_Magus</Target>
+			</Effect>
+			<Effect type="Data" action="Convert" amount="0.6668" scaling="0.0000" subtype="WorkRate" unittype="ConvertableSiege" relativity="Percent">
+				<Target type="ProtoUnit">Pe_Spc_Magus</Target>
+			</Effect>
+			<Effect type="SetName" proto="Pe_Spc_Magus" culture="none" newName="110051"/>							
+		</Effects>
+	</Tech>
+	
+	<Tech name="PVP_BabylonTechPriest1" type="Normal">
+		<DBID>5750</DBID>
+		<DisplayNameID>66214</DisplayNameID>
+		<Cost resourcetype="Gold">1000.0000</Cost>
+		<ResearchPoints>60.0000</ResearchPoints>
+		<Status>UNOBTAINABLE</Status>
+		<Icon>\UserInterface\Icons\Techs\C06TechCodeofHammurabi_ua</Icon>
+		<RolloverTextID>110049</RolloverTextID>
+		<ContentPack>22</ContentPack>
+		<Flag>IsAward</Flag>
+		<Prereqs>
+			<SpecificAge>Age3</SpecificAge>
+		</Prereqs>
+		<Effects>
+			<Effect type="Data" action="Convert" amount="0.8500" scaling="0.0000" subtype="WorkRate" unittype="StandardConvertable" relativity="Percent">
+				<Target type="ProtoUnit">Ba_Spc_Priest</Target>
+			</Effect>
+			<Effect type="Data" action="Convert" amount="0.8500" scaling="0.0000" subtype="WorkRate" unittype="ConvertableInfantry" relativity="Percent">
+				<Target type="ProtoUnit">Ba_Spc_Priest</Target>
+			</Effect>
+			<Effect type="Data" action="Convert" amount="0.8500" scaling="0.0000" subtype="WorkRate" unittype="ConvertableCavalry" relativity="Percent">
+				<Target type="ProtoUnit">Ba_Spc_Priest</Target>
+			</Effect>
+			<Effect type="Data" action="Convert" amount="0.8500" scaling="0.0000" subtype="WorkRate" unittype="ConvertableSiege" relativity="Percent">
+				<Target type="ProtoUnit">Ba_Spc_Priest</Target>
+			</Effect>
+			<Effect type="Data" action="Convert" amount="1.1000" scaling="0.0000" subtype="MaximumRange" relativity="Percent">
+				<Target type="ProtoUnit">Ba_Spc_Priest</Target>
+			</Effect>
+			<Effect type="Data" amount="1.1000" scaling="0.0000" subtype="LOS" relativity="Percent">
+				<Target type="ProtoUnit">Ba_Spc_Priest</Target>
+			</Effect>
+			<Effect type="SetName" proto="Ba_Spc_Priest" culture="none" newName="110050"/>				
+		</Effects>
+	</Tech>	
+	
+	<Tech name="PVP_CeltTechDruidHeal" type="Normal">
+		<DBID>5751</DBID>
+		<DisplayNameID>59028</DisplayNameID>
+		<Cost resourcetype="Food">200.0000</Cost>
+		<Cost resourcetype="Gold">300.0000</Cost>
+		<ResearchPoints>60.0000</ResearchPoints>
+		<Status>UNOBTAINABLE</Status>
+		<Icon>\UserInterface\Icons\Techs\C03TechGiftofSequana_ua</Icon>
+		<RolloverTextID>59027</RolloverTextID>
+		<ContentPack>5</ContentPack>
+		<Flag>IsAward</Flag>
+		<Prereqs>
+			<SpecificAge>Age2</SpecificAge>
+		</Prereqs>
+		<Effects>
+			<Effect type="Data" action="Heal" amount="1.4000" scaling="0.0000" subtype="WorkRate" unittype="LogicalTypeHealed" relativity="Percent">
+				<Target type="ProtoUnit">Ce_Spc_Druid</Target>
+			</Effect>
+			<Effect type="Data" action="Heal" amount="1.4000" scaling="0.0000" subtype="WorkRate" unittype="LogicalTypeHealed" relativity="Percent">
+				<Target type="ProtoUnit">Ce_Spc_DruidAugur</Target>
+			</Effect>
+			<Effect type="SetName" proto="Ce_Spc_Druid" culture="none" newName="110052"/>	
+			<Effect type="SetName" proto="Ce_Spc_DruidAugur" culture="none" newName="110053"/>				
+		</Effects>
+	</Tech>	
+	
+	<Tech name="PVP_GreekTechPriestRange1" type="Normal">
+		<DBID>5752</DBID>
+		<DisplayNameID>52290</DisplayNameID>
+		<Cost resourcetype="Gold">800.0000</Cost>
+		<ResearchPoints>60.0000</ResearchPoints>
+		<Status>UNOBTAINABLE</Status>
+		<Icon>UserInterface\Icons\Techs\GrE_GreekTechPriestRange1_ua</Icon>
+		<RolloverTextID>52289</RolloverTextID>
+		<ContentPack>1</ContentPack>
+		<Flag>IsAward</Flag>
+		<Prereqs>
+			<SpecificAge>Age3</SpecificAge>
+		</Prereqs>
+		<Effects>
+			<Effect type="Data" action="Convert" amount="1.2000" scaling="0.0000" subtype="MaximumRange" relativity="Percent">
+				<Target type="ProtoUnit">Gr_Spc_Priest</Target>
+			</Effect>
+			<Effect type="Data" amount="1.2000" scaling="0.0000" subtype="LOS" relativity="Percent">
+				<Target type="ProtoUnit">Gr_Spc_Priest</Target>
+			</Effect>
+			<Effect type="SetName" proto="Gr_Spc_Priest" culture="none" newName="110050"/>			
+		</Effects>
+	</Tech>
+	
+	<Tech name="PVP_NorseTechWarDog_Upgrade1" type="Normal">
+		<DBID>5753</DBID>
+		<DisplayNameID>67600</DisplayNameID>
+		<Cost resourcetype="Food">100.0000</Cost>
+		<Cost resourcetype="Wood">150.0000</Cost>
+		<ResearchPoints>40.0000</ResearchPoints>
+		<Status>UNOBTAINABLE</Status>
+		<Icon>\UserInterface\Icons\Techs\C07TechWarDogChampion_ua</Icon>
+		<RolloverTextID>67599</RolloverTextID>
+		<ContentPack>24</ContentPack>
+		<Flag>IsAward</Flag>
+		<Prereqs>
+			<SpecificAge>Age1</SpecificAge>
+		</Prereqs>
+		<Effects>
+			<Effect type="Data" amount="12.0000" scaling="0.0000" subtype="BuildLimit" relativity="Absolute">
+				<Target type="ProtoUnit">No_Cav_WarDog</Target>
+			</Effect>
+			<Effect type="Data" amount="0.7000" scaling="0.0000" subtype="TrainPoints" relativity="Percent">
+				<Target type="ProtoUnit">No_Cav_WarDog</Target>
+			</Effect>
+		</Effects>
+		<Effect type="SetName" proto="No_Cav_WarDog" culture="none" newName="110054"/>			
+	</Tech>	
+	
 </TechTree>

--- a/techtreexStatlessOverrides.xml
+++ b/techtreexStatlessOverrides.xml
@@ -55,19 +55,25 @@
 	<!-- Celeste Balance Changes New Techs  -->
 	
 	<!-- UNIT - GE -->
+
+	<Tech name="GreekTechRam_Upgrade1">PVP_GreekTechRam_Upgrade1</Tech>		
+	<Tech name="GreekTechPriestRange1">PVP_GreekTechPriestRange1</Tech>	
 	
 	<!-- UNIT - EG -->
 
 	<Tech name="EgyptTechElephantArcher_Upgrade1">PVP_EgyptTechElephantArcher_Upgrade1</Tech>
+	<Tech name="EgyptTechSiegeTower_Upgrade1">PVP_EgyptTechSiegeTower_Upgrade1</Tech>	
 	
 	<!-- UNIT - PE -->
 	
 	<Tech name="PersiaTechArcRange1">PVP_PersiaTechArcRange1</Tech>
 	<Tech name="PersiaTechBatteringRam_Upgrade1">PVP_PersiaTechBatteringRam_Upgrade1</Tech>	
+	<Tech name="PersiaTechZorostrianConvert1">PVP_PersiaTechZorostrianConvert1</Tech>	
 	
 	<!-- UNIT - CE -->	
 	
 	<Tech name="CeltTechBardHall3">PVP_CeltTechBardHall3</Tech>
+	<Tech name="CeltTechDruidHeal">PVP_CeltTechDruidHeal</Tech>	
 	
 	<!-- UNIT - BA -->
 	
@@ -80,6 +86,7 @@
 	<Tech name="BabylonTechSlinger_Upgrade1">PVP_BabylonTechSlinger_Upgrade1</Tech>
 	<Tech name="BabylonTechGarden_Upgrade1">PVP_BabylonTechGarden_Upgrade1</Tech>
 	<Tech name="BabylonTechGarden_Upgrade2">PVP_BabylonTechGarden_Upgrade2</Tech>
+	<Tech name="BabylonTechPriest1">PVP_BabylonTechPriest1</Tech>	
 
 	<!-- UNIT - NO -->
 	
@@ -87,5 +94,6 @@
 	<Tech name="NorseTechRaider_Upgrade1">PVP_NorseTechRaider_Upgrade1</Tech>
 	<Tech name="NorseCapAge2">PVP_NorseCapAge2</Tech>
 	<Tech name="NorseTechBerserker_Upgrade1">PVP_NorseTechBerserker_Upgrade1</Tech>	
+	<Tech name="NorseTechWarDog_Upgrade1">PVP_NorseTechWarDog_Upgrade1</Tech>		
 	
 </TechTreeOverrides>


### PR DESCRIPTION
Greeks:

Battering Ram: Champion upgrade cost reduced to 300g, from 400g. Research time reduced to 30s, from 60s.

Priests: Researching Divine Vision will now also rename the unit to "Grand Priest". Convert rate reduced to 15, from 16.

--------------------
Egyptians:

Siege Tower: Champion upgrade cost reduced to 300g, from 400g. Research time reduced to 30s, from 60s.

--------------------
Persians:

Mounted Archer: DPS reduced to 14, from 16. Bonus Multiplier increased to 2.3x, from 2x.

Paid Labor: Train time reduction reduced to 33%, from 45%

Magus: Researching Without Number now renames the unit to "Celestial Magus". Upgrade cost reduced to 800g, from 1000g. Convert rate reduced to 15, from 16.

Battering Ram: Champion upgrade cost reduced to 300g, from 400g. Research time reduced to 30s, from 60s.

--------------------
Celts:

Champion: Hitpoints increased to 450, from 420.

Gift of Sequana: Now also renames Druids and Augurs to "Elder Druid" and "Elder Augur"

--------------------
Babylonians:

Priest: Researching Code of Hammurabi will now rename the unit to "Grand Priest". Upgrade cost reduced to 1000g, from 1200g. Convert rate reduced to 15, from 16.

--------------------
Norse:

War Dogs: Researching Dog Training will now rename the unit to "War Hound"

Rhapsode: Convert rate reduced to15, from 16.

Seer: Convert rate reduced to 15, from 16.

--------------------
General Changes:

---